### PR TITLE
Aw 115 frontend main header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.6",
         "react-router-dom": "^6.2.1",
-        "react-scripts": "5.0.0",
+        "react-scripts": "^5.0.0",
         "redux-logger": "^3.0.6",
         "styled-components": "^5.3.3",
         "web-vitals": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.1",
-    "react-scripts": "5.0.0",
+    "react-scripts": "^5.0.0",
     "redux-logger": "^3.0.6",
     "styled-components": "^5.3.3",
     "web-vitals": "^2.1.4"

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,34 @@
+import React from "react";
+import { Route, Routes } from "react-router-dom";
+import styled from "styled-components";
+
+import MainHeader from "./components/MainHeader";
+
 function App() {
-  return <div className="App"></div>;
+  return (
+    <div>
+      <MainHeader />
+      <Main>
+        <Routes>
+          <Route path="/" />
+          <Route path="/counsels/*">
+            <Route path=":counsel_id/*" />
+            <Route path=":counsel_id/counselors/:user_id" />
+            <Route path=":counsel_id/room" />
+          </Route>
+          <Route path="/counsels/new" />
+          <Route path="/mypage">
+            <Route path="/mypage/counselor" />
+            <Route path="/mypage/stories" />
+          </Route>
+        </Routes>
+      </Main>
+    </div>
+  );
 }
 
 export default App;
+
+const Main = styled.main`
+  margin: 20px;
+`;

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 import MainHeader from "./components/MainHeader";
 
-function App() {
+export default function App() {
   return (
     <div>
       <MainHeader />
@@ -26,8 +26,6 @@ function App() {
     </div>
   );
 }
-
-export default App;
 
 const Main = styled.main`
   margin: 20px;

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -44,24 +44,24 @@ const MainHeaderContainer = styled.div`
   height: 130px;
 
   nav {
-    height: 100%;
     display: grid;
     grid-template-columns: 150px auto 50px;
     align-items: center;
+    height: 100%;
   }
 
   .mainHeader-link {
-    height: 100%;
-    padding: 0;
     display: flex;
-    align-items: center;
     justify-content: flex-end;
+    align-items: center;
+    padding: 0;
+    height: 100%;
     list-style: none;
   }
 
   .mainHeader-link li {
-    width: 100px;
     margin: 0 20px;
+    width: 100px;
   }
 
   .mainHeader-link a {

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -46,7 +46,9 @@ const MainHeaderContainer = styled.div`
   nav {
     display: grid;
     grid-template-columns: 150px auto 50px;
+    column-gap: 30px;
     align-items: center;
+    margin: 20px;
     height: 100%;
   }
 

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -1,0 +1,79 @@
+import React from "react";
+import { NavLink, Link } from "react-router-dom";
+import styled from "styled-components";
+
+export default function MainHeader() {
+  return (
+    <MainHeaderContainer>
+      <nav>
+        <section>
+          <Link to="/">
+            <div className="logo">
+              <h2>anon-wall</h2>
+            </div>
+          </Link>
+        </section>
+        <ul className="mainHeader-link">
+          <li>
+            <NavLink
+              to="/counsels"
+              className={(navData) => (navData.isActive ? "active" : "")}
+            >
+              고민 담벼락
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/mypage"
+              className={(navData) => (navData.isActive ? "active" : "")}
+            >
+              나의 담벼락
+            </NavLink>
+          </li>
+        </ul>
+        <section>
+          <div>login</div>
+        </section>
+      </nav>
+    </MainHeaderContainer>
+  );
+}
+
+const MainHeaderContainer = styled.div`
+  width: 100%;
+  height: 130px;
+
+  nav {
+    height: 100%;
+    display: grid;
+    grid-template-columns: 150px auto 50px;
+    align-items: center;
+  }
+
+  .mainHeader-link {
+    height: 100%;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    list-style: none;
+  }
+
+  .mainHeader-link li {
+    width: 100px;
+    margin: 0 20px;
+  }
+
+  .mainHeader-link a {
+    color: black;
+    text-decoration: none;
+  }
+
+  .mainHeader-link a:hover,
+  .mainHeader-link a:active,
+  .mainHeader-link a.active {
+    padding-bottom: 0.25rem;
+    border-bottom: 4px solid #95bcf0;
+    color: #95bcf0;
+  }
+`;

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -17,7 +17,7 @@ export default function MainHeader() {
           <li>
             <NavLink
               to="/counsels"
-              className={(navData) => (navData.isActive ? "active" : "")}
+              className={({ isActive }) => (isActive ? "active" : "")}
             >
               고민 담벼락
             </NavLink>
@@ -25,7 +25,7 @@ export default function MainHeader() {
           <li>
             <NavLink
               to="/mypage"
-              className={(navData) => (navData.isActive ? "active" : "")}
+              className={({ isActive }) => (isActive ? "active" : "")}
             >
               나의 담벼락
             </NavLink>


### PR DESCRIPTION
# AW-115 MainHeader

## Jira KANBAN 링크
[husky 셋업](https://merkyuri.atlassian.net/browse/AW-115?atlOrigin=eyJpIjoiYjRhOGViM2FjOWRjNDhjYjkxNDliYjY1NjU0MTczYWIiLCJwIjoiaiJ9)


## 카드에서 구현 혹은 해결하려는 내용
- 프론트앤드의 라우트 설정(App.js)
- MainHeader navLink설정.
- 선택한 헤더에 스타일(색깔변경, 밑줄) 남아있게 하기.
​
## 테스트 방법
```javascript
function App() {
  return (
    <div>
      <MainHeader />
      <Main>
        <Routes>
          <Route path="/" element={<Test />} /> //원하는 컴포넌트 element에 넣기
    </div>
  );
}
```
## 기타 사항
스타일 색상은 제가 임의로 넣어둔 거라서 나중에 같이 이야기해봐도 좋을 것 같습니다!
