### PR TITLE
[AW-106] 고민 세부사항 페이지 (본인 외)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,19 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
-import styled from "styled-components";
 
 import MainHeader from "./components/MainHeader";
 import Home from "./components/Home";
+import StoryDetail from "./components/StroyDetail";
 
 export default function App() {
   return (
     <div>
       <MainHeader />
-      <Main>
+      <main>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/counsels/*">
+          <Route path="/counsels">
+            <Route path=":counsel_id" element={<StoryDetail />} />
             <Route path=":counsel_id/*" />
             <Route path=":counsel_id/counselors/:user_id" />
             <Route path=":counsel_id/room" />
@@ -23,11 +24,7 @@ export default function App() {
             <Route path="/mypage/stories" />
           </Route>
         </Routes>
-      </Main>
+      </main>
     </div>
   );
 }
-
-const Main = styled.main`
-  margin: 20px;
-`;

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -5,12 +5,12 @@ import styled from "styled-components";
 import Modal from "./common/Modal";
 import homeImage from "../assets/tree.png";
 
-export default function Home() {
-  const welcomeMessage =
-    "주변에 말 못할 고민이 있으신가요? 익명의 사람들과 고민을 나눠보세요!";
-  const buttonName = "Discover Now";
-  const copyright = "All rights reserved to anon-wall";
+const welcomeMessage =
+  "주변에 말 못할 고민이 있으신가요? 익명의 사람들과 고민을 나눠보세요!";
+const buttonName = "Discover Now";
+const copyright = "All rights reserved to anon-wall";
 
+export default function Home() {
   const [isModalOn, setIsModalOn] = useState(false);
 
   const handleModalOn = () => {

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -8,13 +8,13 @@ export default function MainHeader() {
   return (
     <MainHeaderContainer>
       <nav>
-        <section>
+        <div>
           <Link to="/">
             <div className="logo">
               <h2>anon-wall</h2>
             </div>
           </Link>
-        </section>
+        </div>
         <ul className="mainHeader-link">
           <li>
             <NavLink
@@ -32,10 +32,10 @@ export default function MainHeader() {
               나의 담벼락
             </NavLink>
           </li>
+          <li>
+            <AuthButton />
+          </li>
         </ul>
-        <section>
-          <AuthButton />
-        </section>
       </nav>
     </MainHeaderContainer>
   );
@@ -48,25 +48,30 @@ const MainHeaderContainer = styled.div`
 
   nav {
     display: grid;
-    grid-template-columns: 150px auto 50px;
+    grid-template-columns: 300px auto 50px;
     column-gap: 30px;
     align-items: center;
-    margin: 20px;
     height: 100%;
+  }
+
+  .logo {
+    margin-left: 5rem;
+    font-size: 2.5rem;
   }
 
   .mainHeader-link {
     display: flex;
     justify-content: flex-end;
     align-items: center;
+    text-align: center;
     padding: 0;
     height: 100%;
     list-style: none;
   }
 
   .mainHeader-link li {
-    margin: 0 20px;
-    width: 100px;
+    font-size: 1.7rem;
+    width: 15rem;
   }
 
   .mainHeader-link a {

--- a/src/components/StroyDetail.js
+++ b/src/components/StroyDetail.js
@@ -6,10 +6,10 @@ import axios from "axios";
 import Modal from "./common/Modal";
 import SubHeader from "./common/SubHeader";
 import StyledLoadingSpinner from "./shared/StyledLoadingSpinner";
-
-const heading = "고민 담벼락";
-const paragraph =
-  "나누고 싶은 고민을 자유롭게 올려주세요. 여러분의 고민을 들어줄 익명의 누군가가 곧 찾아올거에요.";
+import {
+  STORY_SUB_HEADER_HEADING,
+  STORY_SUB_HEADER_PARAGRAPH,
+} from "../constants/story";
 
 export default function StoryDetail() {
   const { counsel_id } = useParams();
@@ -17,7 +17,7 @@ export default function StoryDetail() {
   const [story, setStory] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOn, setIsModalOn] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -30,7 +30,7 @@ export default function StoryDetail() {
 
       if (data.message) {
         setErrorMessage(data.message);
-        setIsModalOpen(true);
+        setIsModalOn(true);
         setIsLoading(false);
 
         return;
@@ -43,11 +43,14 @@ export default function StoryDetail() {
 
   return (
     <>
-      <SubHeader heading={heading} paragraph={paragraph} />
+      <SubHeader
+        heading={STORY_SUB_HEADER_HEADING}
+        paragraph={STORY_SUB_HEADER_PARAGRAPH}
+      />
       <MainContainer>
         {isLoading && <StyledLoadingSpinner />}
-        {!isLoading && errorMessage && isModalOpen ? (
-          <Modal onClick={setIsModalOpen} width="150px" height="50px">
+        {!isLoading && errorMessage && isModalOn ? (
+          <Modal onClick={setIsModalOn} width="150px" height="50px">
             {errorMessage}
           </Modal>
         ) : null}
@@ -90,7 +93,7 @@ const MainContainer = styled.section`
   display: flex;
   justify-content: center;
   width: 80%;
-  height: 100vh;
+  min-height: 100vh;
   margin: 0 auto;
 
   section {

--- a/src/components/StroyDetail.js
+++ b/src/components/StroyDetail.js
@@ -59,7 +59,7 @@ export default function StoryDetail() {
             <section>
               <StoryHeaderWrapper>
                 <ImageWrapper>
-                  <img src={story.counslee.imageURL} alt="Profile Image" />
+                  <img src={story.counselee.imageURL} alt="Profile Image" />
                 </ImageWrapper>
                 <StoryInfoWrapper>
                   <div className="name">{story.counselee.nickname}</div>

--- a/src/components/StroyDetail.js
+++ b/src/components/StroyDetail.js
@@ -1,42 +1,86 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
+import axios from "axios";
 
+import Modal from "./common/Modal";
 import SubHeader from "./common/SubHeader";
+import StyledLoadingSpinner from "./shared/StyledLoadingSpinner";
+
+const heading = "고민 담벼락";
+const paragraph =
+  "나누고 싶은 고민을 자유롭게 올려주세요. 여러분의 고민을 들어줄 익명의 누군가가 곧 찾아올거에요.";
 
 export default function StoryDetail() {
+  const { counsel_id } = useParams();
+
+  const [story, setStory] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await axios.get(
+        `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/counsels/${counsel_id}`,
+        {
+          withCredentials: true,
+        }
+      );
+
+      if (data.message) {
+        setErrorMessage(data.message);
+        setIsModalOpen(true);
+        setIsLoading(false);
+
+        return;
+      }
+
+      setStory(data.data);
+      setIsLoading(false);
+    })();
+  }, [setStory]);
+
   return (
     <>
-      <SubHeader
-        heading="고민 담벼락"
-        paragraph="나누고 싶은 고민을 자유롭게 올려주세요. 여러분의 고민을 들어줄 익명의 누군가가 곧 찾아올거에요."
-      />
+      <SubHeader heading={heading} paragraph={paragraph} />
       <MainContainer>
-        <section>
-          <StoryHeaderWrapper>
-            <ImageWrapper>
-              <img />
-            </ImageWrapper>
-            <StoryInfoWrapper>
-              <div className="name">켄 아버지</div>
-              <div className="title">요즘 힘들어요</div>
-              <div className="tags">#소통 #코딩 #바닐라코딩</div>
-            </StoryInfoWrapper>
-          </StoryHeaderWrapper>
-          <StoryBodyWrapper>
-            <p>
-              Lorem, ipsum dolor sit amet consectetur adipisicing elit.
-              Inventore sapiente nobis consectetur. Quidem quasi repellat vitae
-              molestiae, quia ratione sequi praesentium veritatis amet
-              architecto aliquam libero maxime in iste. Dolore!
-            </p>
-          </StoryBodyWrapper>
-        </section>
-        <aside>
-          <AsideWrapper>
-            <ButtonWrapper>
-              <button>사연 수락하기</button>
-            </ButtonWrapper>
-          </AsideWrapper>
-        </aside>
+        {isLoading && <StyledLoadingSpinner />}
+        {!isLoading && errorMessage && isModalOpen ? (
+          <Modal onClick={setIsModalOpen} width="150px" height="50px">
+            {errorMessage}
+          </Modal>
+        ) : null}
+        {!isLoading && !errorMessage && story ? (
+          <>
+            <section>
+              <StoryHeaderWrapper>
+                <ImageWrapper>
+                  <img src={story.counslee.imageURL} alt="Profile Image" />
+                </ImageWrapper>
+                <StoryInfoWrapper>
+                  <div className="name">{story.counselee.nickname}</div>
+                  <div className="title">{story.title}</div>
+                  <div className="tags">
+                    {story.tag.map((tag) => {
+                      return <Tag key={tag}>#{tag}</Tag>;
+                    })}
+                  </div>
+                </StoryInfoWrapper>
+              </StoryHeaderWrapper>
+              <StoryBodyWrapper>
+                <p>{story.content}</p>
+              </StoryBodyWrapper>
+            </section>
+            <aside>
+              <AsideWrapper>
+                <ButtonWrapper>
+                  <button>사연 수락하기</button>
+                </ButtonWrapper>
+              </AsideWrapper>
+            </aside>
+          </>
+        ) : null}
       </MainContainer>
     </>
   );
@@ -68,6 +112,7 @@ const StoryHeaderWrapper = styled.div`
   margin-top: 3rem;
   border: 0.8rem solid #bfaea4;
   border-radius: 3rem;
+  overflow: scroll;
 `;
 
 const ImageWrapper = styled.div`
@@ -97,6 +142,10 @@ const StoryInfoWrapper = styled.div`
     font-size: 3rem;
     color: #3e005b;
   }
+`;
+
+const Tag = styled.span`
+  margin: 0 1rem;
 `;
 
 const StoryBodyWrapper = styled.div`

--- a/src/components/StroyDetail.js
+++ b/src/components/StroyDetail.js
@@ -1,0 +1,136 @@
+import styled from "styled-components";
+
+import SubHeader from "./common/SubHeader";
+
+export default function StoryDetail() {
+  return (
+    <>
+      <SubHeader
+        heading="고민 담벼락"
+        paragraph="나누고 싶은 고민을 자유롭게 올려주세요. 여러분의 고민을 들어줄 익명의 누군가가 곧 찾아올거에요."
+      />
+      <MainContainer>
+        <section>
+          <StoryHeaderWrapper>
+            <ImageWrapper>
+              <img />
+            </ImageWrapper>
+            <StoryInfoWrapper>
+              <div className="name">켄 아버지</div>
+              <div className="title">요즘 힘들어요</div>
+              <div className="tags">#소통 #코딩 #바닐라코딩</div>
+            </StoryInfoWrapper>
+          </StoryHeaderWrapper>
+          <StoryBodyWrapper>
+            <p>
+              Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+              Inventore sapiente nobis consectetur. Quidem quasi repellat vitae
+              molestiae, quia ratione sequi praesentium veritatis amet
+              architecto aliquam libero maxime in iste. Dolore!
+            </p>
+          </StoryBodyWrapper>
+        </section>
+        <aside>
+          <AsideWrapper>
+            <ButtonWrapper>
+              <button>사연 수락하기</button>
+            </ButtonWrapper>
+          </AsideWrapper>
+        </aside>
+      </MainContainer>
+    </>
+  );
+}
+
+const MainContainer = styled.section`
+  display: flex;
+  justify-content: center;
+  width: 80%;
+  height: 100vh;
+  margin: 0 auto;
+
+  section {
+    flex-basis: 70%;
+    height: 100%;
+  }
+
+  aside {
+    flex-basis: 30%;
+    height: 100%;
+  }
+`;
+
+const StoryHeaderWrapper = styled.div`
+  display: flex;
+  width: 90%;
+  height: 20%;
+  margin: 0 auto;
+  margin-top: 3rem;
+  border: 0.8rem solid #bfaea4;
+  border-radius: 3rem;
+`;
+
+const ImageWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 30rem;
+  height: 100%;
+  background-color: #000000;
+
+  img {
+    width: 20rem;
+    height: 20rem;
+    border-radius: 50%;
+    background-color: #ffffff;
+  }
+`;
+
+const StoryInfoWrapper = styled.div`
+  width: 100%;
+  margin: auto;
+  font-size: 2.5rem;
+  text-align: center;
+  line-height: 6rem;
+
+  .name {
+    font-size: 3rem;
+    color: #3e005b;
+  }
+`;
+
+const StoryBodyWrapper = styled.div`
+  width: 90%;
+  height: 70%;
+  padding: 5rem;
+  margin: 0 auto;
+  margin-top: 3rem;
+  border: 0.8rem solid #bfaea4;
+  border-radius: 3rem;
+  font-size: 2.5rem;
+  overflow-y: auto;
+`;
+
+const AsideWrapper = styled.div`
+  width: 90%;
+  height: 92.5%;
+  min-height: 92.5%;
+  margin: 0 auto;
+  margin-top: 3rem;
+  border: 0.8rem solid #bfaea4;
+  border-radius: 3rem;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+
+  button {
+    font-size: 3.5rem;
+    padding: 1rem;
+    border-radius: 3rem;
+  }
+`;

--- a/src/components/common/SubHeader.js
+++ b/src/components/common/SubHeader.js
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+export default function SubHeader({ heading, paragraph }) {
+  return (
+    <SubHeaderWrapper>
+      <div className="headingWrapper">
+        <h2>{heading}</h2>
+      </div>
+      <div className="paragraphWrapper">
+        <p>{paragraph}</p>
+      </div>
+    </SubHeaderWrapper>
+  );
+}
+
+const SubHeaderWrapper = styled.div`
+  width: 100%;
+  height: 20rem;
+  background-color: #dedfac;
+  text-align: center;
+
+  .headingWrapper {
+    height: 30%;
+  }
+
+  .paragraphWrapper {
+    height: 65%;
+  }
+
+  h2 {
+    width: 50%;
+    margin: 0 auto;
+    padding-top: 2rem;
+    font-size: 3.5rem;
+  }
+
+  p {
+    display: block;
+    width: 60%;
+    margin: 0 auto;
+    margin-top: 3rem;
+    font-size: 2rem;
+    overflow: auto;
+  }
+`;
+
+SubHeader.propTypes = {
+  heading: PropTypes.string,
+  paragraph: PropTypes.string,
+};

--- a/src/components/shared/StyledAuthButton.js
+++ b/src/components/shared/StyledAuthButton.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export default styled.button`
+const StyledAuthButton = styled.button`
   width: 100px;
   height: 20px;
   background-color: transparent;
@@ -8,3 +8,5 @@ export default styled.button`
   cursor: pointer;
   font-size: 17px;
 `;
+
+export default StyledAuthButton;

--- a/src/components/shared/StyledLoadingSpinner.js
+++ b/src/components/shared/StyledLoadingSpinner.js
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
 const LoadingSpinner = styled.div`
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
   border: 15px solid #f3f3f3;
   border-top: 16px solid #0e0f0f21;
   border-radius: 50%;
-  width: ${(props) => props.width};
-  height: ${(props) => props.height};
   animation: spin 1s linear infinite;
 
   @keyframes spin {

--- a/src/components/shared/StyledLoadingSpinner.js
+++ b/src/components/shared/StyledLoadingSpinner.js
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+
+const LoadingSpinner = styled.div`
+  border: 15px solid #f3f3f3;
+  border-top: 16px solid #0e0f0f21;
+  border-radius: 50%;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
+  animation: spin 1s linear infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+LoadingSpinner.defaultProps = {
+  width: "120px",
+  height: "120px",
+};
+
+export default LoadingSpinner;

--- a/src/constants/story.js
+++ b/src/constants/story.js
@@ -1,0 +1,3 @@
+export const STORY_SUB_HEADER_HEADING = "고민 담벼락";
+export const STORY_SUB_HEADER_PARAGRAPH =
+  "나누고 싶은 고민을 자유롭게 올려주세요. 여러분의 고민을 들어줄 익명의 누군가가 곧 찾아올거에요.";

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -4,16 +4,27 @@ import axios from "axios";
 import { auth } from "../api/firebase";
 
 export const login = createAsyncThunk("user/login", async (loginData) => {
-  const userData = await axios.post("/api/auth/login", loginData);
+  const userData = await axios.post(
+    `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/auth/login`,
+    loginData,
+    {
+      withCredentials: true,
+    }
+  );
 
-  return userData;
+  return userData.data;
 });
 
 export const logout = createAsyncThunk("user/logout", async () => {
-  const userData = await axios.get("/api/auth/logout");
+  const userData = await axios.get(
+    `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/auth/logout`,
+    {
+      withCredentials: true,
+    }
+  );
   await auth.signOut();
 
-  return userData;
+  return userData.data;
 });
 
 const initialState = {

--- a/src/theme/globalStyle.js
+++ b/src/theme/globalStyle.js
@@ -2,7 +2,7 @@ import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
   :root {
-    font-size: 10px;
+    font-size: 62.5%;
   }
 
   * {

--- a/src/theme/globalStyle.js
+++ b/src/theme/globalStyle.js
@@ -1,6 +1,10 @@
 import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
+  :root {
+    font-size: 10px;
+  }
+
   * {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
[AW-106] 고민 세부사항 페이지 (본인 외)
## 지라 칸반 링크
- [[Frontend] 고민 세부사항 페이지 (본인 외)](https://merkyuri.atlassian.net/browse/AW-106)
  ​
## 카드에서 구현 혹은 해결하려는 내용
- 고민 세부사항 페이지 UI 구현 및 Fetch해온 데이터 렌더링
- 고민 작성자가 아닌 사람이 페이지에 들어왔을 경우 사연 수락하기 버튼이 보인다.
- LoadingSpinner 재사용 로딩 컴포넌트
- SubHeader 재사용 컴포넌트

## 테스트 방법
- DB에 Counsel 데이터를 요청하여 보이는 것을 테스트할 수 있습니다.

## 기타 사항
- POST 요청은 백엔드 구현후에 작업하면 좋을 것 같습니다!


[AW-106]: https://merkyuri.atlassian.net/browse/AW-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ