### PR TITLE
[AW-116] 사이드바 스타일 컴포넌트

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,21 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
+import styled from "styled-components";
 
 import MainHeader from "./components/MainHeader";
 import Home from "./pages/Home";
-import NotFound from "./components/NotFound";
 import StoryList from "./pages/StoryList";
 import StoryDetail from "./pages/StoryDetail";
 import CounselorDetail from "./components/CounselorDetail";
+import Sidebar from "./components/SideBar";
+import Counselor from "./pages/Counselor";
+import NotFound from "./components/NotFound";
 
 function App() {
   return (
     <div>
       <MainHeader />
-      <main>
+      <Main>
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/counsels" element={<StoryList />} />
@@ -23,15 +26,20 @@ function App() {
           />
           <Route path="/counsels/:counsel_id/room" />
           <Route path="/counsels/new" />
-          <Route path="/mypage">
-            <Route path="/mypage/counselor" />
+          <Route path="/mypage" element={<Sidebar />}>
+            <Route path="/mypage/main" />
+            <Route path="/mypage/counselor" element={<Counselor />} />
             <Route path="/mypage/stories" />
           </Route>
           <Route path="/*" element={<NotFound />} />
         </Routes>
-      </main>
+      </Main>
     </div>
   );
 }
+
+const Main = styled.main`
+  position: relative;
+`;
 
 export default App;

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { NavLink, Outlet } from "react-router-dom";
+import styled from "styled-components";
+
+function Sidebar() {
+  return (
+    <>
+      <SideBarContainer>
+        <nav>
+          <ul className="sidebar-link">
+            <li>
+              <NavLink
+                to="/mypage/main"
+                className={({ isActive }) => (isActive ? "active" : "")}
+              >
+                내정보
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                to="/mypage/counselor"
+                className={({ isActive }) => (isActive ? "active" : "")}
+              >
+                카운슬러
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                to="/mypage/stories"
+                className={({ isActive }) => (isActive ? "active" : "")}
+              >
+                나의 고민
+              </NavLink>
+            </li>
+          </ul>
+        </nav>
+      </SideBarContainer>
+      <Outlet />
+    </>
+  );
+}
+
+const SideBarContainer = styled.div`
+  width: 20rem;
+  height: 70rem;
+  margin: 4rem 4rem;
+  border: 0.7rem solid #bfaea4;
+  border-radius: 3rem;
+
+  .sidebar-link {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    text-align: center;
+    margin: 9rem 0;
+    padding: 0;
+    height: 100%;
+    list-style: none;
+  }
+
+  .sidebar-link li {
+    font-size: 1.7rem;
+    width: 15rem;
+    margin: 3.5rem 0;
+  }
+
+  .sidebar-link a {
+    color: black;
+    text-decoration: none;
+  }
+
+  .sidebar-link a:hover,
+  .sidebar-link a:active,
+  .sidebar-link a.active {
+    padding: 2rem;
+    background-color: #e5e5e5;
+    border-radius: 50px;
+  }
+`;
+
+export default Sidebar;

--- a/src/components/shared/MyPageWrapper.js
+++ b/src/components/shared/MyPageWrapper.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+const MyPageWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 27rem;
+  width: 80%;
+  height: 100%;
+  border: 0.7rem solid #bfaea4;
+  border-radius: 3rem;
+`;
+
+export default MyPageWrapper;

--- a/src/pages/Counselor.js
+++ b/src/pages/Counselor.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import MyPageWrapper from "../components/shared/MyPageWrapper";
+
+function Counselor() {
+  return <MyPageWrapper></MyPageWrapper>;
+}
+
+export default Counselor;


### PR DESCRIPTION
# [AW-116] {[Frontend] SideBar}

## 지라 칸반 링크

- [[Frontend] SideBar](https://merkyuri.atlassian.net/browse/AW-116?atlOrigin=eyJpIjoiYjg0MTkzZjZmYWMzNGZhNWJlYjBlNGUzMzJjYWU2YWQiLCJwIjoiaiJ9)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- ​마이페이지에 들어가면 화면 왼쪽에 계속 보이도록 사이드바 구현
- shared폴더에 있는 MyPageWrapper적용해서 쓰셔야 position: absolute 적용됩니다!

## 테스트 방법
- pages에 MyPageWrapper Counselor 컴포넌트를 만들어 놓았습니다. 해당라우트로 들어가시면 보실 수 있어요!
-

## 기타 사항

- 그 외 코드 내용에서 읽는 사람이 이해하기 어렵거나, 이렇게 구현하는게 맞는지 고민되는 부분이 있으면 코멘트 달기
- 그 외 코드 내용에서 리뷰어가 이해하기 어렵거나, 이렇게 구현하는게 맞는지 고민되는 부분이 있으면 코멘트 달기


[AW-116]: https://merkyuri.atlassian.net/browse/AW-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ