### PR TITLE
[AW-127] 로그인 유저 검증

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^9.6.6",
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
+        "react-cookie": "^4.1.1",
         "react-datepicker": "^4.6.0",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.6",
@@ -4039,6 +4040,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
@@ -14582,6 +14588,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-datepicker": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.6.0.tgz",
@@ -16901,6 +16920,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "node_modules/universalify": {
@@ -20814,6 +20842,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "@types/eslint": {
       "version": "7.29.0",
@@ -28443,6 +28476,16 @@
         "whatwg-fetch": "^3.6.2"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-datepicker": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.6.0.tgz",
@@ -30160,6 +30203,15 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "firebase": "^9.6.6",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
+    "react-cookie": "^4.1.1",
     "react-datepicker": "^4.6.0",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",

--- a/src/App.js
+++ b/src/App.js
@@ -58,8 +58,12 @@ function App() {
               element={<CounselorDetail />}
             />
           </Route>
-          <Route path="/counsels/:counsel_id/room" element={<ChatRoom />} />
-          <Route path="/counsels/new" element={<UploadStory />} />
+          <Route element={<PrivateRoute />}>
+            <Route path="/counsels/:counsel_id/room" element={<ChatRoom />} />
+          </Route>
+          <Route element={<PrivateRoute />}>
+            <Route path="/counsels/new" element={<UploadStory />} />
+          </Route>
           <Route element={<PrivateRoute />}>
             <Route path="/mypage" element={<MyPage />}>
               <Route element={<PrivateRoute />}>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
-import React from "react";
-import { Routes, Route } from "react-router-dom";
+import React, { useState, useEffect } from "react";
+import { Routes, Route, useNavigate } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
 
 import MainHeader from "./components/MainHeader";
 import Home from "./pages/Home";
@@ -12,27 +13,65 @@ import MyPageCounselor from "./pages/MyPageCounselor";
 import ChatRoom from "./components/ChatRoom";
 import NotFound from "./components/NotFound";
 import MyPage from "./pages/MyPage";
+import PrivateRoute from "./components/PrivateRoute";
+import Modal from "./components/common/Modal";
 import UserStoryList from "./pages/UserStoryList";
+import { getCookie } from "./api/cookie";
+import { getLoginUserByToken } from "./features/userSlice";
 
 function App() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const isLoggedIn = useSelector(({ user }) => user.isLoggedIn);
+
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (!isLoggedIn && getCookie("accessToken")) {
+      dispatch(getLoginUserByToken(setErrorMessage));
+    }
+  }, []);
+
+  function handleClickGoHomeButton() {
+    navigate("/");
+  }
+
   return (
     <div>
+      {errorMessage && (
+        <Modal width="50rem" height="20rem">
+          <div>{errorMessage}</div>
+          <button onClick={handleClickGoHomeButton}>홈으로</button>
+        </Modal>
+      )}
       <MainHeader />
       <main>
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/counsels" element={<StoryList />} />
-          <Route path="/counsels/:counsel_id" element={<StoryDetail />} />
-          <Route
-            path="/counsels/:counsel_id/counselors/:user_id"
-            element={<CounselorDetail />}
-          />
+          <Route element={<PrivateRoute />}>
+            <Route path="/counsels/:counsel_id" element={<StoryDetail />} />
+          </Route>
+          <Route element={<PrivateRoute />}>
+            <Route
+              path="/counsels/:counsel_id/counselors/:user_id"
+              element={<CounselorDetail />}
+            />
+          </Route>
           <Route path="/counsels/:counsel_id/room" element={<ChatRoom />} />
           <Route path="/counsels/new" element={<UploadStory />} />
-          <Route path="/mypage" element={<MyPage />}>
-            <Route path="/mypage/main" element={<MyPageMain />} />
-            <Route path="/mypage/counselor" element={<MyPageCounselor />} />
-            <Route path="/mypage/stories" element={<UserStoryList />} />
+          <Route element={<PrivateRoute />}>
+            <Route path="/mypage" element={<MyPage />}>
+              <Route element={<PrivateRoute />}>
+                <Route path="/mypage/main" element={<MyPageMain />} />
+              </Route>
+              <Route element={<PrivateRoute />}>
+                <Route path="/mypage/counselor" element={<MyPageCounselor />} />
+              </Route>
+              <Route element={<PrivateRoute />}>
+                <Route path="/mypage/stories" element={<UserStoryList />} />
+              </Route>
+            </Route>
           </Route>
           <Route path="/*" element={<NotFound />} />
         </Routes>

--- a/src/api/cookie.js
+++ b/src/api/cookie.js
@@ -1,0 +1,15 @@
+import { Cookies } from "react-cookie";
+
+const cookies = new Cookies();
+
+export function setCookie(name, value, options) {
+  return cookies.set(name, value, { ...options });
+}
+
+export function getCookie(name) {
+  return cookies.get(name);
+}
+
+export function removeCookie(name) {
+  return cookies.remove(name);
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,54 @@
+import axios from "axios";
+import { signInWithPopup } from "firebase/auth";
+
+import { setCookie, getCookie } from "./cookie";
+import { auth, provider } from "../api/firebase";
+
+export async function firebaseLogin() {
+  try {
+    const { user } = await signInWithPopup(auth, provider);
+    const userData = {
+      email: user.email,
+    };
+
+    const { data } = await axios.post(
+      `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/auth/login`,
+      userData,
+      {
+        withCredentials: true,
+      }
+    );
+
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 1);
+
+    setCookie("accessToken", data.data.accessToken, {
+      path: "/",
+      secure: true,
+      expires,
+    });
+
+    return data.data.user;
+  } catch (err) {
+    throw new Error("로그인에 실패하였습니다.");
+  }
+}
+
+export async function getLoginedUser() {
+  try {
+    if (!getCookie("accessToken")) {
+      throw new Error("로그인이 필요합니다.");
+    }
+
+    const { data } = await axios.get(
+      `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/users`,
+      {
+        withCredentials: true,
+      }
+    );
+
+    return data.data.user;
+  } catch (err) {
+    throw new Error("로그인에 실패하였습니다.");
+  }
+}

--- a/src/components/AuthButton.js
+++ b/src/components/AuthButton.js
@@ -1,41 +1,22 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { signInWithPopup } from "firebase/auth";
 
-import StyledTransparentButton from "./shared/StyledTransparentButton";
 import Modal from "./common/Modal";
+import StyledTransparentButton from "./shared/StyledTransparentButton";
 import { login, logout } from "../features/userSlice";
-import { auth, provider } from "../api/firebase";
 
 function AuthButton() {
-  const rejectedLoginError = useSelector(({ user }) => user.error);
   const isLoggedIn = useSelector(({ user }) => !user.isLoggedIn);
   const dispatch = useDispatch();
 
   const [errorMessage, setErrorMessage] = useState(false);
 
-  useEffect(() => {
-    setErrorMessage(rejectedLoginError);
-  }, [rejectedLoginError]);
-
-  async function handleClickLoginButton() {
-    try {
-      const { user } = await signInWithPopup(auth, provider);
-      const userData = {
-        email: user.email,
-      };
-      dispatch(login(userData));
-    } catch (err) {
-      setErrorMessage(err);
-    }
+  function handleClickLoginButton() {
+    dispatch(login(setErrorMessage));
   }
 
-  async function handleClickLogoutButton() {
-    try {
-      dispatch(logout());
-    } catch (err) {
-      setErrorMessage(err);
-    }
+  function handleClickLogoutButton() {
+    dispatch(logout());
   }
 
   return (
@@ -50,7 +31,7 @@ function AuthButton() {
         </StyledTransparentButton>
       )}
       {errorMessage && (
-        <Modal onClick={setErrorMessage} width="500px" height="200px">
+        <Modal onClick={setErrorMessage} width="50rem" height="20rem">
           <p>{errorMessage}</p>
         </Modal>
       )}

--- a/src/components/ChatRoom.js
+++ b/src/components/ChatRoom.js
@@ -9,7 +9,7 @@ import { differenceInSeconds } from "date-fns";
 import Modal from "./common/Modal";
 import Video from "./Video";
 import useFetch from "../hooks/useFetch";
-import LoadingSpinner from "./shared/StyledLoadingSpinner";
+import StyledLoadingSpinner from "./shared/StyledLoadingSpinner";
 
 const socket = io.connect("http://localhost:8000");
 
@@ -211,7 +211,7 @@ function ChatRoom() {
 
   return (
     <>
-      {isLoading && <LoadingSpinner />}
+      {isLoading && <StyledLoadingSpinner />}
       {!isLoading && (errorMessage || fetchError) && isModalOn && (
         <Modal onClick={setIsModalOn} width="40rem" height="20rem">
           {errorMessage || fetchError}

--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+import { useSelector } from "react-redux";
+
+import Modal from "./common/Modal";
+
+function PrivateRoute() {
+  const isLoggedIn = useSelector(({ user }) => user.isLoggedIn);
+  const navigate = useNavigate();
+
+  function handleClickGoHomeButton() {
+    navigate("/");
+  }
+
+  return (
+    <>
+      {isLoggedIn ? (
+        <Outlet />
+      ) : (
+        <Modal width="50rem" height="20rem">
+          <div>로그인이 필요합니다.</div>
+          <button onClick={handleClickGoHomeButton}>홈으로</button>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default PrivateRoute;

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,15 +1,21 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Icon } from "@iconify/react";
 
 import { RESTRICT_REGEX } from "../constants/upload";
 import StyledTransparentButton from "../components/shared/StyledTransparentButton";
+import Modal from "../components/common/Modal";
 
 function SearchBar({ onSubmitKeyword }) {
+  const navigate = useNavigate();
+
   const [tag, setTag] = useState("");
   const [errorMessage, setErrorMessage] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const isLoggedIn = useSelector(({ user }) => user.isLoggedIn);
 
   function handleChangeTag(tag) {
     const reg = /[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/ ]/gim;
@@ -26,13 +32,26 @@ function SearchBar({ onSubmitKeyword }) {
     onSubmitKeyword(tag);
   }
 
+  function handleClickButtonUpload() {
+    if (!isLoggedIn) {
+      setModalMessage("로그인이 필요합니다.");
+      return;
+    }
+    navigate("/counsels/new");
+  }
+
   return (
     <SearchBarContainer>
-      <Link to="/counsels/new">
-        <div className="button-container">
-          <StyledTransparentButton>고민 올리기</StyledTransparentButton>
-        </div>
-      </Link>
+      {modalMessage && (
+        <Modal onClick={setModalMessage} width="50rem" height="20rem">
+          {modalMessage}
+        </Modal>
+      )}
+      <div className="button-container">
+        <StyledTransparentButton onClick={handleClickButtonUpload}>
+          고민 올리기
+        </StyledTransparentButton>
+      </div>
       <form className="search-container" onSubmit={handleSubmitTag}>
         <input
           type="text"

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import PropTypes from "prop-types";
@@ -15,7 +14,6 @@ function SearchBar({ onSubmitKeyword }) {
   const [tag, setTag] = useState("");
   const [errorMessage, setErrorMessage] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
-  const isLoggedIn = useSelector(({ user }) => user.isLoggedIn);
 
   function handleChangeTag(tag) {
     const reg = /[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/ ]/gim;
@@ -33,10 +31,6 @@ function SearchBar({ onSubmitKeyword }) {
   }
 
   function handleClickButtonUpload() {
-    if (!isLoggedIn) {
-      setModalMessage("로그인이 필요합니다.");
-      return;
-    }
     navigate("/counsels/new");
   }
 

--- a/src/components/UserStoryLIstEntry.js
+++ b/src/components/UserStoryLIstEntry.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-function StoryListEntry({ id, title, endDate, counselors }) {
+function UserStoryListEntry({ id, title, endDate, counselors }) {
   const navigate = useNavigate();
 
   function handleClickStoryDetail() {
@@ -33,12 +33,11 @@ const MyStoryInfoWrapper = styled.div`
   width: 100%;
 `;
 
-StoryListEntry.propTypes = {
+UserStoryListEntry.propTypes = {
   id: PropTypes.string.isRequired,
-  nickname: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   endDate: PropTypes.string.isRequired,
   counselors: PropTypes.any,
 };
 
-export default StoryListEntry;
+export default UserStoryListEntry;

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -22,10 +22,13 @@ const ModalWrapper = styled.div`
   left: 50%;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
+  padding: 3rem;
   background-color: #fff;
   border-radius: 10px;
   box-shadow: rgba(0, 0, 0, 0.5);
   transform: translate(-50%, -50%);
+  font-size: 1.7rem;
+  font-weight: bold;
 `;
 
 const OverlayWrapper = styled.div`
@@ -39,7 +42,7 @@ const OverlayWrapper = styled.div`
 `;
 
 Modal.propTypes = {
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   width: PropTypes.string.isRequired,
   height: PropTypes.string.isRequired,
 };

--- a/src/components/shared/StyledLoadingSpinner.js
+++ b/src/components/shared/StyledLoadingSpinner.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const LoadingSpinner = styled.div`
+const StyledLoadingSpinner = styled.div`
   width: ${(props) => props.width};
   height: ${(props) => props.height};
   border: 15px solid #f3f3f3;
@@ -18,9 +18,9 @@ const LoadingSpinner = styled.div`
   }
 `;
 
-LoadingSpinner.defaultProps = {
+StyledLoadingSpinner.defaultProps = {
   width: "120px",
   height: "120px",
 };
 
-export default LoadingSpinner;
+export default StyledLoadingSpinner;

--- a/src/features/counselorSlice.js
+++ b/src/features/counselorSlice.js
@@ -6,7 +6,6 @@ export const getCounselorInfo = createAsyncThunk(
   async (userId) => {
     const { data } = await axios.get(
       `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/users/${userId}`,
-      userId,
       {
         withCredentials: true,
       }

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -20,7 +20,7 @@ export const login = createAsyncThunk(
 
 export const getLoginUserByToken = createAsyncThunk(
   "user/getLoginUserByToken",
-  async ({ setErrorMessage }, { rejectWithValue }) => {
+  async (setErrorMessage, { rejectWithValue }) => {
     try {
       const response = await getLoginedUser();
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -9,9 +9,9 @@ import { WELCOME_MESSAGE, BUTTON_NAME, COPYRIGHT } from "../constants/home";
 function Home() {
   const [isModalOn, setIsModalOn] = useState(false);
 
-  const handleModalOn = () => {
+  function handleModalOn() {
     setIsModalOn(true);
-  };
+  }
 
   return (
     <>

--- a/src/pages/StoryDetail.js
+++ b/src/pages/StoryDetail.js
@@ -24,8 +24,6 @@ function StoryDetail() {
   const [isLoading, setIsLoading] = useState(true);
   const handleClickMemoized = useCallback(handleClick, [userId]);
 
-  console.log(story);
-
   useEffect(() => {
     (async () => {
       try {

--- a/src/pages/StoryList.js
+++ b/src/pages/StoryList.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import axios from "axios";
 
+import StyledLoadingSpinner from "../components/shared/StyledLoadingSpinner";
 import SubHeader from "../components/common/SubHeader";
 import Modal from "../components/common/Modal";
 import StyledTransparentButton from "../components/shared/StyledTransparentButton";
@@ -16,6 +17,7 @@ import {
 
 function StoryList() {
   const [storyList, setStoryList] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState(false);
   const [page, setPage] = useState(1);
   const [keyword, setKeyword] = useState("");
@@ -30,18 +32,20 @@ function StoryList() {
         const { data } = await axios.get(
           `${process.env.REACT_APP_LOCAL_SERVER_URL}/api/counsels`,
           {
-            params: { page, limit: 6, tag: keyword },
+            params: { page: 1, limit: 6, tag: keyword },
             withCredentials: true,
           }
         );
 
         setStoryList(data.data.pageCounsels);
+        setIsLoading(false);
         setHasPage({
           ...hasPage,
           prev: data.data.hasPrevPage,
           next: data.data.hasNextPage,
         });
       } catch (err) {
+        setIsLoading(false);
         setErrorMessage(err.response.data.message);
       }
     })();
@@ -62,7 +66,8 @@ function StoryList() {
 
   return (
     <>
-      {errorMessage && (
+      {isLoading && <StyledLoadingSpinner />}
+      {!isLoading && errorMessage && (
         <Modal onClick={setErrorMessage} width="50rem" height="20rem">
           <p>{errorMessage}</p>
         </Modal>

--- a/src/pages/UserStoryList.js
+++ b/src/pages/UserStoryList.js
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import styled from "styled-components";
 import axios from "axios";
 
-import UserStoryLIstEntry from "../components/UserStoryLIstEntry";
+import UserStoryListEntry from "../components/UserStoryLIstEntry";
 import Modal from "../components/common/Modal";
 import StyledTransparentButton from "../components/shared/StyledTransparentButton";
 import { PREV, NEXT } from "../constants/story";
@@ -64,7 +64,7 @@ function UserStoryList() {
           const numberOfRequest = counselors.length;
 
           return (
-            <UserStoryLIstEntry
+            <UserStoryListEntry
               key={_id}
               id={_id}
               title={title}


### PR DESCRIPTION
# [AW-127] {로그인 유저 검증}

- [[Frontend] 로그인 유저 쿠키 저장, 새로고침 대응](https://merkyuri.atlassian.net/browse/AW-127?atlOrigin=eyJpIjoiMWJjMjUxZGNmNzJlNDdhNWJjZDM2NTIzMTUyMTNlZTIiLCJwIjoiaiJ9)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- ​백앤드에서 jwt토큰을 바로 cookie에 넣어줬었는데 jwt토큰을 바디에 받아서 프론트에서 쿠키에 넣어주도록 변경함.(리액트 쿠키 라이브러리 사용)
- 유저가 새로고침시 쿠키는 남아있고 리덕스는 초기상태로 돌아가기 때문에 쿠키가 존재한다면 유저의 정보를 리덕스에 다시 넣어줄 수 있게 만듦.
- 로그인하지 않은 유저는 고민리스트 페이지에만 접근할 수 있고 다른 페이지에는 접근하지 못하게 만듦.
- 로그인에 관한 axios 파일 분리

## 테스트 방법

-
-

## 기타 사항

- 그 외 코드 내용에서 읽는 사람이 이해하기 어렵거나, 이렇게 구현하는게 맞는지 고민되는 부분이 있으면 코멘트 달기
- 그 외 코드 내용에서 리뷰어가 이해하기 어렵거나, 이렇게 구현하는게 맞는지 고민되는 부분이 있으면 코멘트 달기
  - 예: (이 부분은 이러이러하게 고민하다가 이렇게 결정했는데 혹시 ~님(리뷰어)은 어떻게 생각하시나요?)
  - 예: (이 부분은 이러이러한 배경 때문에 가독성이 떨어지지만 이렇게 짜게 됐습니다.)


[AW-127]: https://merkyuri.atlassian.net/browse/AW-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ