### PR TITLE
[AW-137] 리다이렉트가 되지 않고 404페이지가 뜨는 이슈

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## 지라 칸반 링크

- [[Frontend] netlify 리다이렉트 이슈](https://merkyuri.atlassian.net/browse/AW-137?atlOrigin=eyJpIjoiNjg1YmNmYWVhZjBmNGVjMWFlNzVjMGU2NzQwY2Y5MjkiLCJwIjoiaiJ9)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- ​ 상담시간이 되면 사용자들은 chatRoom에 입장하는데 이때 리다이렉트로 chatRoom으로 가게 만들었음.
- 하지만 netlify에서 리다이렉트를 하게 되면 404이슈 발생
- netlify.toml에 내용을 넣어 파일 추가.

